### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 matrix:
   include:
   - php: 7.1
+  - php: 7.2
   - php: nightly
 
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     "php": ">=7.1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.5.*"
+    "phpunit/phpunit": "^6.5"
   },
   "scripts": {
-    "test": "phpunit -c phpunit.xml"
+    "test": "phpunit"
   }
 }

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -4,15 +4,17 @@ namespace CrazyFactory\Utils\Tests;
 
 
 use CrazyFactory\Utils\Format;
+use PHPUnit\Framework\TestCase;
 
-class FormatTest extends \PHPUnit_Framework_TestCase
+class FormatTest extends TestCase
 {
     public function provideTestTimeElapsed() {
         return [
             [50, "50s"],
             [70, "01m 10s"],
             [3696, "01h 01m 36s"],
-            [7200, "02h 00m 00s"]
+            [7200, "02h 00m 00s"],
+            [null, ""]
         ];
     }
 


### PR DESCRIPTION
# Changed log
- Add the `php-7.2` test in Travis CI build.
- Let the PHPUnit version `^6.5` in `composer.json` because the package requires PHP version is `php-7.1+`.
- Using the class-based PHPUnit namespace is for the latest PHPUnit version.
- Add the other test case.