### PR TITLE
feat(FileSystem): Add mkdir and rm

### DIFF
--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CrazyFactory\Utils;
+
+class FileSystem
+{
+
+    /**
+     * Recursively removes files and directories
+     *
+     * @param string $path
+     * @return bool
+     */
+    public static function rm(string $path): bool
+    {
+        if (!file_exists($path)) {
+            return true;
+        }
+
+        if (is_dir($path)) {
+            foreach (array_diff(scandir($path), ['.', '..']) as $filename) {
+                static::rm($path . '/' . $filename);
+            }
+
+            return rmdir($path);
+        }
+        else {
+            return unlink($path);
+        }
+    }
+
+    /**
+     * Creates a directory recursively and sets directory permissions to 777
+     *
+     * @param string $path
+     * @param int $permissions
+     * @return bool
+     */
+    public static function mkdir(string $path, $permissions = 777): bool
+    {
+        if (file_exists($path)) {
+            return true;
+        }
+
+        return mkdir($path, $permissions, true);
+    }
+
+}

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -6,7 +6,7 @@ class FileSystem
 {
 
     /**
-     * Recursively removes files and directories
+     * Remove files and directories recursively
      *
      * @param string $path
      * @return bool
@@ -30,7 +30,7 @@ class FileSystem
     }
 
     /**
-     * Creates a directory recursively and sets directory permissions to 777
+     * Create a directory recursively
      *
      * @param string $path
      * @param int $permissions

--- a/tests/FileSystemTest.php
+++ b/tests/FileSystemTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CrazyFactory\Utils\Tests;
+
+use CrazyFactory\Utils\FileSystem;
+use PHPUnit\Framework\TestCase;
+
+class FileSystemTest extends TestCase
+{
+    /** @var null|string */
+    static $cachePath;
+
+    public static function setUpBeforeClass()
+    {
+        self::$cachePath = __DIR__ . '/.cache';
+
+        if (file_exists(self::$cachePath)) {
+            rmdir(self::$cachePath);
+        }
+    }
+
+    public function testMkdir()
+    {
+        $this->assertDirectoryNotExists(self::$cachePath);
+
+        $this->assertTrue(FileSystem::mkdir(self::$cachePath));
+
+        $this->assertDirectoryExists(self::$cachePath);
+
+        $this->assertTrue(FileSystem::mkdir(self::$cachePath));
+
+        rmdir(self::$cachePath);
+    }
+
+    public function testRm()
+    {
+        $path = self::$cachePath . '/test/test';
+        $filePath = $path . '/test.txt';
+
+        mkdir($path, 0777, true);
+
+        fopen($filePath, "w");
+
+        $this->assertDirectoryExists($path);
+        $this->assertFileExists($filePath);
+
+        $this->assertTrue(FileSystem::rm(self::$cachePath));
+
+        $this->assertDirectoryNotExists(self::$cachePath);
+    }
+
+}


### PR DESCRIPTION
This will add `FileSystem::mkdir()` and `FileSystem::rm()`

This is intended as a replacement for the same methods in DF in the shop, and as common utilities that we can use in packages.

