### PR TITLE
fix(FileSystem): Permissions default needs to be 0777

### DIFF
--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -36,7 +36,7 @@ class FileSystem
      * @param int $permissions
      * @return bool
      */
-    public static function mkdir(string $path, $permissions = 777): bool
+    public static function mkdir(string $path, $permissions = 0777): bool
     {
         if (file_exists($path)) {
             return true;


### PR DESCRIPTION
Permissions should be 0777, not 777.

The bug was preventing directories from being created with the correct permissions.

The bug showed up here:

https://travis-ci.com/crazyfactory/shop-mailing/jobs/137540660